### PR TITLE
Fix backup.j2 to include DB dump

### DIFF
--- a/templates/backup.j2
+++ b/templates/backup.j2
@@ -85,9 +85,9 @@ ynh_print_info "Backing up the {{ data.database }} database..."
 ### copy of the generated dump to the archive still happens later)
 {% endif %}
 
-{% if data.use_db == 'mysql' -%}
+{% if data.database == 'mysql' -%}
 ynh_mysql_dump_db > db.sql
-{% elif data.use_db == 'postgresql' -%}
+{% elif data.database == 'postgresql' -%}
 ynh_psql_dump_db > db.sql
 {% endif %}
 {% endif %}


### PR DESCRIPTION
When using a database, the backup script contains comments and a `ynh_print_info` call, but is missing the commands to actually create the DB dump. It looks like this is caused by the template checking for `data.use_db` instead of `data.database`. Maybe a leftover of a rename? 
Anyways, this PR fixes that. A quick test by hand with the dev server confirms that the command is now included correctly for MySQL and Postgres.
I also did a search around the repo for `use_db` and found no other occurences, so this should be the only place where this happened.