### PR TITLE
Fix call to ynh_script_progression in upgrade.j2

### DIFF
--- a/templates/upgrade.j2
+++ b/templates/upgrade.j2
@@ -67,7 +67,7 @@ ynh_go_install
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
-ynh_script_progression --message="Upgrading source files..."
+ynh_script_progression "Upgrading source files..."
 
 ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="{{ data.custom_config_file }}"
 


### PR DESCRIPTION
In one place in upgrade.j2, ynh_script_progression is called with a --message flag instead of just passing the message as an argument.
This results in "--message" being included in the output when running the upgrade script:
`Info: [####++++............] > --message=Upgrading source files...`

I searched the repo for "--message" and found no other occurences.