### PR TITLE
Don't require french description

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,7 +126,6 @@ class GeneralInfos(FlaskForm):
         description=_(
             "Explain in a few words (10-15) why this app is useful or what it does (the goal is to give a broad idea for the user browsing an hundred apps long catalog"
         ),
-        validators=[DataRequired()],
     )
 
 


### PR DESCRIPTION
Not every contributor speaks French :)

If omitted, it renders this in the manifest:
```toml
packaging_format = 2

id = "my_awesome_app"
name = "My Awesome app"

description.en = "English Description"
description.fr = ""
```

I don't know if that's OK to leave it empty or if the `description.fr` attributes would be better omitted.